### PR TITLE
Command line script

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -78,7 +78,7 @@ class convert_csscheme(WindowAndTextCommand):  # noqa
             executables = settings().get("executables", {})
 
             # Run converter
-            text = conv.convert(out, in_file, executables)
+            text = conv.convert(out, in_file, executables, sublime.platform() == 'windows')
             if not text:
                 return
 

--- a/converters/__init__.py
+++ b/converters/__init__.py
@@ -4,8 +4,6 @@ import re
 import os
 import subprocess
 
-import sublime
-
 __all__ = ('all', 'CSSConverter', 'SCSSConverter', 'SASSConverter', 'StylusConverter')
 
 

--- a/converters/__init__.py
+++ b/converters/__init__.py
@@ -50,12 +50,13 @@ class BaseConverter(object):
         return file_path.endswith('.' + cls.ext)
 
     @classmethod
-    def convert(cls, out, file_path, executables):
+    def convert(cls, out, file_path, executables, shell):
         """Convert the specified file to CSScheme and return as string.
 
         * out - output panel to write output to
         * file_path - file to convert
         * executables - dict with optional path settings
+        * shell - whether to invoke external commands using shell
         """
         # Just read the file when we have no executable
         if not cls.default_executable:
@@ -77,7 +78,7 @@ class BaseConverter(object):
             process = subprocess.Popen(cmd,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
-                                       shell=sublime.platform() == 'windows',
+                                       shell=shell,
                                        universal_newlines=True)
             stdout, stderr = process.communicate()
         except Exception as e:

--- a/converters/tmtheme.py
+++ b/converters/tmtheme.py
@@ -23,8 +23,6 @@ def load(text, path, out):
     """
     dirname = os.path.dirname(path)
     out.set_path(dirname, file_regex)
-    if text.startswith('<?xml version="1.0" encoding="UTF-8"?>'):
-        text = text[38:]
 
     try:
         from xml.parsers.expat import ExpatError, ErrorString

--- a/converters/tmtheme.py
+++ b/converters/tmtheme.py
@@ -111,7 +111,11 @@ def to_csscheme(data, out, skip_names, hidden=False):
                 out.write_line("Missing 'settings' key in item")
                 return
             for key, value in item['settings'].items():
-                stream.write("\n\t%s: %s;" % (key, value))
+                # translate an empty fontStyle into fontStyle: none
+                if (key == "fontStyle" and value == ""):
+                    stream.write("\n\tfontStyle: none;")
+                else:
+                    stream.write("\n\t%s: %s;" % (key, value))
 
             stream.write("\n}")
 

--- a/csscheme.py
+++ b/csscheme.py
@@ -1,6 +1,3 @@
-import sys
-sys.modules["sublime"] = __import__("mock_sublime")
-
 import converters
 from converters import tmtheme
 from tinycsscheme import parser, dumper
@@ -22,7 +19,8 @@ def main():
 
 
 def validate_extensions(tmtheme, csscheme):
-    return csscheme.endswith(tuple("." + c.ext for c in converters.all)) and tmtheme.lower().endswith(".tmtheme")
+    return (csscheme.endswith(tuple("." + c.ext for c in converters.all))
+            and tmtheme.lower().endswith(".tmtheme"))
 
 
 def convert_tmtheme_to_csscheme(input_file, output_file, skip_names=False):
@@ -40,16 +38,15 @@ def convert_tmtheme_to_csscheme(input_file, output_file, skip_names=False):
         f.write(csscheme)
 
 
-
 def convert_csscheme_to_tmtheme(input_file, output_file):
     # determine the converter to use
     possible_converters = [c for c in converters.all if c.valid_file(input_file)]
     if len(possible_converters) > 1:
-        error("found multiple possible converters")
+        error("Found multiple possible converters")
         return
     if len(possible_converters) == 0:
-        known_extensions = ["." + c.ext for c in converters.all]
-        error(f"no converters found for this file extension. Known extensions are {known_extensions}")
+        exts = ["." + c.ext for c in converters.all]
+        error("No converters found for this file extension. Known extensions are " + str(exts))
         return
 
     converter = possible_converters[0]
@@ -69,7 +66,6 @@ def convert_csscheme_to_tmtheme(input_file, output_file):
         dumper.dump_stylesheet_file(output_file, stylesheet)
     except dumper.DumpError as ex:
         converter.report_dump_error(out, input_file, output, ex)
-
 
 
 class MockSublimeOutputPanel:

--- a/csscheme.py
+++ b/csscheme.py
@@ -1,0 +1,91 @@
+import sys
+sys.modules["sublime"] = __import__("mock_sublime")
+
+import converters
+from converters import tmtheme
+from tinycsscheme import parser, dumper
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert between csscheme and tmTheme format")
+    parser.add_argument("input")
+    parser.add_argument("output")
+    parser.add_argument("--skip-names", action='store_true')
+
+    args = parser.parse_args()
+
+    if validate_extensions(tmtheme=args.input, csscheme=args.output):
+        convert_tmtheme_to_csscheme(args.input, args.output, args.skip_names)
+    elif validate_extensions(tmtheme=args.output, csscheme=args.input):
+        convert_csscheme_to_tmtheme(args.input, args.output)
+
+
+def validate_extensions(tmtheme, csscheme):
+    return csscheme.endswith(tuple("." + c.ext for c in converters.all)) and tmtheme.lower().endswith(".tmtheme")
+
+
+def convert_tmtheme_to_csscheme(input_file, output_file, skip_names=False):
+
+    out = MockSublimeOutputPanel()
+
+    with open(input_file, "r") as f:
+        input = f.read()
+
+    input_text = tmtheme.load(input, "", out)
+
+    csscheme = tmtheme.to_csscheme(input_text, out, skip_names)
+
+    with open(output_file, "w") as f:
+        f.write(csscheme)
+
+
+
+def convert_csscheme_to_tmtheme(input_file, output_file):
+    # determine the converter to use
+    possible_converters = [c for c in converters.all if c.valid_file(input_file)]
+    if len(possible_converters) > 1:
+        error("found multiple possible converters")
+        return
+    if len(possible_converters) == 0:
+        known_extensions = ["." + c.ext for c in converters.all]
+        error(f"no converters found for this file extension. Known extensions are {known_extensions}")
+        return
+
+    converter = possible_converters[0]
+
+    out = MockSublimeOutputPanel()
+
+    output = converter.convert(out, input_file, {}, True)
+
+    stylesheet = parser.parse_stylesheet(output)
+
+    if stylesheet.errors:
+        converter.report_parse_errors(out, input_file, output, stylesheet.errors)
+
+    # TODO: support hidden at-rule
+
+    try:
+        dumper.dump_stylesheet_file(output_file, stylesheet)
+    except dumper.DumpError as ex:
+        converter.report_dump_error(out, input_file, output, ex)
+
+
+
+class MockSublimeOutputPanel:
+    def write_line(self, message):
+        print(message)
+
+    def set_regex(self, regex):
+        pass
+
+    def set_path(self, dirname, regex):
+        pass
+
+
+def error(reason):
+    print("error:", reason)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have created a command line script to run the converter outside of Sublime, `csscheme.py`.

I've also fixed a few things. I don't have Sublime Text, perhaps you can test whether it still functions correctly in Sublime? Is there in any harm in the script I have added being present or does it need to be moved elsewhere?

My motivation is wanting to develop vscode syntax themes (which must be in tmTheme format).

"Hidden" themes are not supported, I don't understand their purpose...